### PR TITLE
Script for downloading and parsing hugging face SEP data

### DIFF
--- a/hfdata.py
+++ b/hfdata.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import pyarrow.parquet as pq
+
+def row_to_article_string(row): 
+    '''Convert a row that represents an SEP article to a string'''
+
+    article_string = row['title'] + ''.join(row['preamble'])
+    
+    for section in row['main_text']: 
+        article_string += '\n' + section['section_title'] + ''.join(section['main_content'])
+        for subsection in section['subsections']:
+            article_string += '\n' + subsection['subsection_title'] + ''.join(subsection['content'])
+
+    return article_string
+
+def main(): 
+    '''Load the data and output each article as txt to directory'''
+
+    table = pq.read_table("hf_data/hf_sep.parquet")
+
+    for row in table.to_pylist():
+        shorturl = row['shorturl']
+        article_string = row_to_article_string(row)
+        with open(f'hf_data/articles/{shorturl}.txt', 'w') as f: 
+            f.write(article_string)
+    
+if __name__ == "__main__": 
+    main()

--- a/hfdata.sh
+++ b/hfdata.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+download_data(){
+    # download the parquet data from hugging face
+    mkdir hf_data 
+    cd hf_data 
+    wget https://huggingface.co/datasets/hugfaceguy0001/stanford_plato/resolve/main/data/train-00000-of-00001-65b5548e09cbc609.parquet
+    mv train-00000-of-00001-65b5548e09cbc609.parquet hf_sep.parquet
+    cd ..
+}
+
+process_data(){
+    # process the data
+    rm -rf hf_data/articles
+    mkdir -p hf_data/articles 
+    python3 hfdata.py
+}
+
+download_data
+process_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 llama-index
 ipdb
+pyarrow


### PR DESCRIPTION
The shell script: 

1. Downloads the hugging face data as a `parquet` file 
2. Runs the Python script 

The python script then: 
1. Loads the data with `pyarrow` (added as dependency) 
2. Converts each article into a `.txt` file in a directory `hf_data/articles`

There might be some more tidying possible with how I am combining everything into the text files, but everything looked reasonable to me on a set of spot checks. Wanted to push this out today before I head out to dinner, but let me know if you have any issues with it. 

@rsepassi 